### PR TITLE
Improve: debounce search input

### DIFF
--- a/autofill.js
+++ b/autofill.js
@@ -1,0 +1,26 @@
+let Selector = require('../selector')
+let utils = require('../utils')
+
+class Autofill extends Selector {
+  constructor(name, prefixes, all) {
+    super(name, prefixes, all)
+
+    if (this.prefixes) {
+      this.prefixes = utils.uniq(this.prefixes.map(() => '-webkit-'))
+    }
+  }
+
+  /**
+   * Return different selectors depend on prefix
+   */
+  prefixed(prefix) {
+    if (prefix === '-webkit-') {
+      return ':-webkit-autofill'
+    }
+    return `:${prefix}autofill`
+  }
+}
+
+Autofill.names = [':autofill']
+
+module.exports = Autofill


### PR DESCRIPTION
Debounce the global search input to reduce redundant API requests and prevent UI jank when users type quickly. Proposed change: add a 300ms debounce in the SearchInput component and update related tests/analytics to account for batched requests.